### PR TITLE
samples: bluetooth: peripheral_mds: Disable `SENSOR_SHELL`

### DIFF
--- a/samples/bluetooth/peripheral_mds/prj.conf
+++ b/samples/bluetooth/peripheral_mds/prj.conf
@@ -29,6 +29,7 @@ CONFIG_LOG_MODE_OVERFLOW=y
 CONFIG_LOG_BACKEND_RTT=n
 
 CONFIG_SHELL=y
+CONFIG_SENSOR_SHELL=n
 CONFIG_DK_LIBRARY=y
 
 # Heap memory is required for the memfault_demo_cli.c


### PR DESCRIPTION
To reduce RAM usage, `SENSOR_SHELL` is disabled.