### PR TITLE
applications: nrf_desktop: Reduce MCUboot FLASH size (serial recovery)

### DIFF
--- a/applications/nrf_desktop/configuration/nrf52820dongle_nrf52820/child_image/mcuboot.overlay
+++ b/applications/nrf_desktop/configuration/nrf52820dongle_nrf52820/child_image/mcuboot.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* The USB is used only for MCUboot serial recovery over CDC ACM class.
+ * Reduce number of endpoints to save memory.
+ */
+&usbd {
+        compatible = "nordic,nrf-usbd";
+        status = "okay";
+        num-bidir-endpoints = <0>;
+        num-in-endpoints = <3>;
+        num-out-endpoints = <2>;
+        num-isoin-endpoints = <0>;
+        num-isoout-endpoints = <0>;
+};

--- a/applications/nrf_desktop/configuration/nrf52833dk_nrf52820/child_image/mcuboot.overlay
+++ b/applications/nrf_desktop/configuration/nrf52833dk_nrf52820/child_image/mcuboot.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* The USB is used only for MCUboot serial recovery over CDC ACM class.
+ * Reduce number of endpoints to save memory.
+ */
+&usbd {
+        compatible = "nordic,nrf-usbd";
+        status = "okay";
+        num-bidir-endpoints = <0>;
+        num-in-endpoints = <3>;
+        num-out-endpoints = <2>;
+        num-isoin-endpoints = <0>;
+        num-isoout-endpoints = <0>;
+};

--- a/applications/nrf_desktop/configuration/nrf52833dk_nrf52833/child_image/mcuboot.overlay
+++ b/applications/nrf_desktop/configuration/nrf52833dk_nrf52833/child_image/mcuboot.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* The USB is used only for MCUboot serial recovery over CDC ACM class.
+ * Reduce number of endpoints to save memory.
+ */
+&usbd {
+        compatible = "nordic,nrf-usbd";
+        status = "okay";
+        num-bidir-endpoints = <0>;
+        num-in-endpoints = <3>;
+        num-out-endpoints = <2>;
+        num-isoin-endpoints = <0>;
+        num-isoout-endpoints = <0>;
+};

--- a/applications/nrf_desktop/configuration/nrf52833dongle_nrf52833/child_image/mcuboot.overlay
+++ b/applications/nrf_desktop/configuration/nrf52833dongle_nrf52833/child_image/mcuboot.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* The USB is used only for MCUboot serial recovery over CDC ACM class.
+ * Reduce number of endpoints to save memory.
+ */
+&usbd {
+        compatible = "nordic,nrf-usbd";
+        status = "okay";
+        num-bidir-endpoints = <0>;
+        num-in-endpoints = <3>;
+        num-out-endpoints = <2>;
+        num-isoin-endpoints = <0>;
+        num-isoout-endpoints = <0>;
+};


### PR DESCRIPTION
Decrease number of USBD endpoints in DTS to reduce FLASH consumption. The MCUboot uses USB only for serial recovery over CDC ACM class.

Jira: NCSDK-22309