### PR TITLE
doc: zephyr: drop upstream additional pages

### DIFF
--- a/doc/zephyr/conf.py
+++ b/doc/zephyr/conf.py
@@ -38,6 +38,7 @@ extensions = ["sphinx.ext.intersphinx"] + extensions
 
 # Options for HTML output ------------------------------------------------------
 
+html_additional_pages = {}
 html_theme = "sphinx_ncs_theme"
 html_theme_path = []
 html_favicon = None


### PR DESCRIPTION
Upstream sets some additional pages for google search which we do not want.