### PR TITLE
applications: asset_tracker_v2: Add missing external flash reference

### DIFF
--- a/applications/asset_tracker_v2/boards/nrf9160dk_nrf9160_ns.overlay
+++ b/applications/asset_tracker_v2/boards/nrf9160dk_nrf9160_ns.overlay
@@ -41,4 +41,17 @@
 			label = "Green LED 4";
 		};
 	};
+
+	/* Configure partition manager to use mx25r64 as the external flash */
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+
+	aliases {
+		ext-flash = &mx25r64;
+	};
+};
+
+&mx25r64 {
+	status = "okay";
 };


### PR DESCRIPTION
Add reference to external flash, pointing to mx25r64, to nrf9160dk_nrf9160_ns.overlay and enable the device.