### PR TITLE
applications: nrf_desktop: Align static PM config for nRF54L15 PDK

### DIFF
--- a/applications/nrf_desktop/configuration/nrf54l15pdk_nrf54l15_cpuapp/boards/nrf54l15pdk_nrf54l15_cpuapp_0_2_1.overlay
+++ b/applications/nrf_desktop/configuration/nrf54l15pdk_nrf54l15_cpuapp/boards/nrf54l15pdk_nrf54l15_cpuapp_0_2_1.overlay
@@ -9,6 +9,11 @@
 	status = "okay";
 };
 
+/* Application does not use cpuflpr core. Assign whole RRAM to cpuapp. */
+&cpuapp_rram {
+	reg = < 0x0 DT_SIZE_K(1524) >;
+};
+
 / {
 	/* Disable pwmleds and redefine them to align configuration with CAF LEDs requirements.
 	 * The configuration needs to match the used board revision (v0.2.0).

--- a/applications/nrf_desktop/configuration/nrf54l15pdk_nrf54l15_cpuapp/boards/nrf54l15pdk_nrf54l15_cpuapp_0_3_0.overlay
+++ b/applications/nrf_desktop/configuration/nrf54l15pdk_nrf54l15_cpuapp/boards/nrf54l15pdk_nrf54l15_cpuapp_0_3_0.overlay
@@ -11,6 +11,11 @@
 	status = "okay";
 };
 
+/* Application does not use cpuflpr core. Assign whole RRAM to cpuapp. */
+&cpuapp_rram {
+	reg = < 0x0 DT_SIZE_K(1524) >;
+};
+
 / {
 	/* Disable pwmleds and redefine them to align configuration with CAF LEDs requirements.
 	 * The configuration needs to match the used board revision (v0.3.0).

--- a/applications/nrf_desktop/configuration/nrf54l15pdk_nrf54l15_cpuapp/child_image/mcuboot.overlay
+++ b/applications/nrf_desktop/configuration/nrf54l15pdk_nrf54l15_cpuapp/child_image/mcuboot.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Application does not use cpuflpr core. Assign whole RRAM to cpuapp. */
+&cpuapp_rram {
+	reg = < 0x0 DT_SIZE_K(1524) >;
+};


### PR DESCRIPTION
Change aligns static Partition Manager configuration after FLPR core support was added to Zephyr. RRAM allocated for FLPR core is not used by application core.

Jira: NCSDK-27508