### PR TITLE
quarantine_zephyr: Add quarantine for drivers.spi*

### DIFF
--- a/scripts/quarantine_zephyr.yaml
+++ b/scripts/quarantine_zephyr.yaml
@@ -619,3 +619,10 @@
   platforms:
     - nrf5340dk/nrf5340/cpuapp/ns
   comment: "Not compatible"
+
+- scenarios:
+    - drivers.spi.nrf_pm_runtime
+    - drivers.spi.loopback
+  platforms:
+    - nrf54h20dk@0.9.0/nrf54h20/cpuppr
+  comment: "https://nordicsemi.atlassian.net/browse/NCSDK-34011"


### PR DESCRIPTION
Test configuration for drivers.spi* on nrf54h20dk/nrf54h20/cpuppr report RAM overflow.