### PR TITLE
quarantine_zephyr: Add quarantine for posix.threads_base.dynamic_stack

### DIFF
--- a/scripts/quarantine_zephyr.yaml
+++ b/scripts/quarantine_zephyr.yaml
@@ -645,3 +645,9 @@
   platforms:
     - nrf54h20dk@0.9.0/nrf54h20/cpuppr
   comment: "sample is native_sim only"
+
+- scenarios:
+    - posix.threads_base.dynamic_stack
+  platforms:
+    - qemu_cortex_m3/ti_lm3s6965
+  comment: "https://github.com/zephyrproject-rtos/zephyr/issues/114095"


### PR DESCRIPTION
Test configuration is added due to overflow.